### PR TITLE
Organize implementations by compiler strategy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,41 @@
 
 ## Implementations
 
-* [Bigloo](https://www-sop.inria.fr/mimosa/fp/Bigloo/): R5RS, compile to C or Java-Virtual-Machine (JVM) classes,
+### Native Compilers
+* [**Chez**](https://cisco.github.io/ChezScheme/): R6RS, official installer also for Windows, considered one of the fastest scheme implementations.
+* [Ikarus](http://ikarus-scheme.org/) R6RS
+* [MIT/GNU Scheme](https://www.gnu.org/software/mit-scheme/): R7RS
+
+### Uses another Scheme as backend
+* [Gerbil](https://cons.io/): R7RS, compiles to C, based on Gambit,  extends gambit with better macro and module systems.
+* [**Racket**](https://racket-lang.org/): R6RS, beginner friendly, full Windows support, optional
+  typing, essentially a superset of scheme,  tons of libraries,  moving/moved to a Chez Scheme backend.
+  
+### Transpilers to C
+* [**Chicken**](https://www.call-cc.org/): R6RS and R7RS, beginner friendly, exceptional community, unique implementation of GC.
+* [Cyclone](https://justinethier.github.io/cyclone/): R7RS,  experimental extension of Chicken-style GC with native thread support.
+* [Gambit](http://dynamo.iro.umontreal.ca/wiki/index.php/Main_Page): R5RS, official installers also for
+  macOS, iOS, Windows, considered quite fast.
+* [Bigloo](https://www-sop.inria.fr/mimosa/fp/Bigloo/): R5RS, can also compile to Java-Virtual-Machine (JVM) classes,
   limited optional typing.
-* [BiwaScheme](https://www.biwascheme.org/): Interpreter written in JavaScript.
-* [Chez](https://cisco.github.io/ChezScheme/): R6RS, generate native code, official installer also for Windows.
-* [Chibi](http://synthcode.com/wiki/chibi-scheme): R7RS, rely on a bytecode Virtual-Machine.
-* [**Chicken**](https://www.call-cc.org/): R6RS and R7RS, compile to C, beginner friendly.
-* [Cyclone](https://justinethier.github.io/cyclone/): R7RS compile to C.
-* [Gambit](http://dynamo.iro.umontreal.ca/wiki/index.php/Main_Page): R5RS, compile to C, official installers also for
-  macOS, iOS, Windows.
-* [Gauche](https://practical-scheme.net/gauche/): R7RS, rely on a bytecode Virtual-Machine, compile to standalone
+  
+### Bytecode VM's and JVM/CLR
+* [Chibi](http://synthcode.com/wiki/chibi-scheme): R7RS
+* [Gauche](https://practical-scheme.net/gauche/): R7RS, compiles to standalone
   executable, official installers also for Windows, Docker.
-* [Gerbil](https://cons.io/): R7RS, compile to C, based on Gambit.
-* [**GNU Guile**](https://www.gnu.org/software/guile/): R6RS, rely on a bytecode Virtual-Machine, beginner friendly.
-* [Ikarus](http://ikarus-scheme.org/) R6RS, generate native code.
+* [**GNU Guile**](https://www.gnu.org/software/guile/): R6RS, getting JIT executable support soon, beginner friendly, officially supported by GNU,  scripting language for many pieces of GNU software.
 * [IronScheme](https://github.com/leppie/IronScheme): R6RS, based on Common-Language-Runtime (CLR).
 * [Kawa](https://www.gnu.org/software/kawa/): R7RS, based on JVM, compile to JVM classes, limited optional typing.
+
+### Javascript Interpreter
+* [BiwaScheme](https://www.biwascheme.org/)
+
+### Unmaintained 
 * [Larceny](http://larcenists.org/): R6RS and R7RS, generate native code, official installers also for macOS, Windows.
-* [MIT/GNU Scheme](https://www.gnu.org/software/mit-scheme/): R7RS, generate native code.
-* [**Racket**](https://racket-lang.org/): R6RS, generate native code, beginner friendly, full Windows support, optional
-  typing.
 * [Scheme48](http://www.s48.org/): classic, unmaintained but useful.
 * [Scsh](https://scsh.net/): classic, unmaintained but useful.
 * [Ypsilon](http://www.littlewingpinball.com/doc/en/ypsilon/index.html): classic, unmaintained but useful.
+
 
 ## Package Managers
 
@@ -62,6 +74,7 @@
 
 * [Bibliography of Scheme-related Research](https://github.com/scheme-live/bibliography#bibliography-of-scheme-related-research)
 * [**Structure and Interpretation of Computer Programs**](https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/book.html): classic computer science textbook from MIT
+* [The Scheme Programming Language 4th Edition](https://www.scheme.com/tspl4/): Written by Kent Dybvig of Chez Scheme fame.
 
 ## Editor and IDEs
 


### PR DESCRIPTION
I organized all the implementations by certain categories of how they actually compile/interpret/run code.  I think it's a little cleaner this way, and gets rid of some of the redundancy.