### PR TITLE
Add r6rs-pffi library

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,8 @@
 
 * _chibi html-parser_: lenient HTML parser (R7RS; [Docs](http://snow-fort.org/s/gmail.com/alexshinn/chibi/html-parser/0.5.7/index.html); Akku, Snow)
 
+## Foreign Function Interface
+
+* _r6rs-pffi_ - portable foreign-function interface for several implementations (R6RS; [Home & Docs](https://github.com/ktakashi/r6rs-pffi); Akku)
+
 ## Past Events


### PR DESCRIPTION
Portable R6RS FFI library with full or partial support for Chez, Larceny, Guile, Racket, Mosh, Vicare, Sagittarius. Similar to CFFI for Common Lisp.