### PR TITLE
Add STklos to the list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 * [**GNU Guile**](https://www.gnu.org/software/guile/): R6RS, getting JIT executable support soon, beginner friendly, officially supported by GNU,  scripting language for many pieces of GNU software.
 * [IronScheme](https://github.com/leppie/IronScheme): R6RS, based on Common-Language-Runtime (CLR).
 * [Kawa](https://www.gnu.org/software/kawa/): R7RS, based on JVM, compile to JVM classes, limited optional typing.
+* [STklos](http://stklos.net): R7RS except for the module system; ad-hoc portable VM, with CLOS-like object system.
 
 ### JavaScript Interpreter
 


### PR DESCRIPTION
STklos is actively maintained, and compiles to a efficient and portable VM. Would fit naturally in the "Bytecode VMs" category.