### PR TITLE
Add JazzScheme to implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 * [Gerbil](https://cons.io/): R7RS, compiles to C, based on Gambit,  extends gambit with better macro and module systems.
 * [**Racket**](https://racket-lang.org/): R6RS, beginner friendly, full Windows support, optional
   typing, essentially a superset of scheme,  tons of libraries,  moving/moved to a Chez Scheme backend.
+* [JazzScheme](https://github.com/jazzscheme/jazz): R6RS, extends Gambit with better macro, module system, OOP, a build system.
 
 ### Transpilers to C
 


### PR DESCRIPTION
[JazzScheme website](http://www.jazzscheme.org/) hasn't been updated for years but the [repository ](https://github.com/jazzscheme/jazz) still get commits regularly.  Since you have to build it yourself, i think it's better to link to the repository instead of the outdated website.

_JazzScheme is a development system based on extending the Scheme programming language and the Gambit system. It includes a module system, hygienic macros, object-oriented programming, a full-featured cross-platform application framework, a fully programmable IDE and a build system that creates executable binaries for Mac OS X, Windows and Linux. JazzScheme has been used for more than 20 years to develop commercial software._ 

