### PR TITLE
Be more precise when describing STklos

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 * [**GNU Guile**](https://www.gnu.org/software/guile/): R6RS, getting JIT executable support soon, beginner friendly, officially supported by GNU,  scripting language for many pieces of GNU software.
 * [IronScheme](https://github.com/leppie/IronScheme): R6RS, based on Common-Language-Runtime (CLR).
 * [Kawa](https://www.gnu.org/software/kawa/): R7RS, based on JVM, compile to JVM classes, limited optional typing.
-* [STklos](http://stklos.net): R7RS except for the module system; ad-hoc portable VM, with CLOS-like object system.
+* [STklos](http://stklos.net): R7RS except that `syntax-rules` only has partial hygiene and lexical scope; ad-hoc portable VM, with CLOS-like object system.
 
 ### Based on JavaScript
 


### PR DESCRIPTION
* The module system is currently R7RS-compiant
* However, although `syntax-rules` works fine, it lacks full lexical scope and symbol renaming (there is partial support).

